### PR TITLE
Use precompressed files instead of gzipping on the fly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+geojson/*
+!geojson/.gitkeep

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:alpine
+FROM nginx:1.25-alpine
 
 RUN apk add --no-cache rsync
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # TTM-backend
 A backend to serve travel time matrices as geodata.
-Matrices are served as catchment polygons in geojson fromat,
-one file per grid cell / travel mode / year combination.
+Matrices are served as catchment polygons in geojson format,
+precompressed with gzip.
+There is one file for every grid cell / travel mode combination.
 
+This repository holds only what is necessary to serve the ready-made data.
 See [preprocessing](https://github.com/DigitalGeographyLab/travel-time-matrix-visualisation-preprocessing)
 for producing the data.
 

--- a/geojson/.gitignore
+++ b/geojson/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/manifest.yml
+++ b/manifest.yml
@@ -34,7 +34,7 @@ spec:
   - ReadOnlyMany
   resources:
     requests:
-      storage: 50Gi
+      storage: 5Gi
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -54,7 +54,7 @@ spec:
     spec:
       containers:
       - name: ttm-server
-        image: ghcr.io/eemilhaa/travel-time-matrix-visualisation-backend:main
+        image: ghcr.io/eemilhaa/travel-time-matrix-visualisation-backend:precompress
         imagePullPolicy: Always  # Change this when stable
         ports:
         - containerPort: 8081  # See Dockerfile

--- a/manifest.yml
+++ b/manifest.yml
@@ -54,7 +54,7 @@ spec:
     spec:
       containers:
       - name: ttm-server
-        image: ghcr.io/eemilhaa/travel-time-matrix-visualisation-backend:precompress
+        image: ghcr.io/eemilhaa/travel-time-matrix-visualisation-backend:main
         imagePullPolicy: Always  # Change this when stable
         ports:
         - containerPort: 8081  # See Dockerfile

--- a/nginx.conf
+++ b/nginx.conf
@@ -32,8 +32,9 @@ http {
 
     keepalive_timeout  65;
 
-    gzip on;
-    gzip_types *;
+    gzip_static  always;
+    gzip_proxied expired no-cache no-store private auth;
+    gunzip       on;
 
     #include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
- This breaks compatibility with uncompressed data